### PR TITLE
Allows large codesets to be parsed

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -94,8 +94,11 @@ function initializeProviders (): void {
 
             getAsmFiles()
                 .then(wsFolders => {
+                    console.log("Resolving Definitions...");
                     asmDefinitionProvider.parseWorkspaceFolders(wsFolders);
+                    console.log("Resolving References...");
                     asmReferenceProvider.parseWorkspaceFolders(wsFolders);
+                    console.log("Project Scan Complete");
 
                     resolve(1);
                 });

--- a/client/src/reference-provider/parse.ts
+++ b/client/src/reference-provider/parse.ts
@@ -2,6 +2,7 @@ import linenumber = require('linenumber');
 import fs = require('fs');
 import { getIncludes, getMatchingVariable, normalizeAliasTemplate } from '../template-utils';
 import { VariablePathDescription, VariablePathMap } from '../interfaces';
+import { nextTick } from 'node:process';
 
 function escapeRegExp (unescapedString: string) {
     return unescapedString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
@@ -11,6 +12,7 @@ function isIncluded (templateName: string, file: string, line: number, allCallMa
     const templatePathDescription: VariablePathDescription[] = allCallMaps[templateName];
 
     if (templatePathDescription) {
+
         const filtered = templatePathDescription.filter(
             (templateData: VariablePathDescription) => templateData.line === line && templateData.path === file
         );
@@ -35,6 +37,10 @@ function insertRefs (templateName: string, path: string, lineNrs: any[], allCall
     lineNrs.forEach(lineItem => {
         const line = lineItem.line - 1;
 
+        const templatePathDescription: VariablePathDescription[] = allCallMaps[templateName];
+        // There's really no reason to insert a reference for usages for more than X times (just do a search or implement that as a plugin action insntead)
+        if(templatePathDescription && templatePathDescription.length >= 30) return; 
+
         if (!isIncluded(templateName, path, line, allCallMaps)) {
             insertElementWithKey(
                 templateName,
@@ -49,19 +55,39 @@ function insertRefs (templateName: string, path: string, lineNrs: any[], allCall
 }
 
 export function parseFile (file: string, allVariablePathMaps: VariablePathMap) {
-    const variablePattern: RegExp = /([\w\d._]+)[\w\d._, #]*/gim;
+    const variablePattern: RegExp = /([\w\d._]+)[\w\d._, #]*/gim; // This regex matches too many unnecesary stuff, it can be checked at https://regexr.com/
     const content: string = fs.readFileSync(file, 'utf8');
     let n: RegExpExecArray;
+    console.log("Parsing File...", file);
 
+    var tt = "c:/Users/rober/Documents/Dev/Github/BeyondMeleeDev/System/asm/m-ex/Main.s"
+    var shouldLog = false ;//file == tt;
+    var alreadyProcessedTemplates = {};
     while (n = variablePattern.exec(content)) {
-        const lineNr = linenumber(content, n[0]);
+        var templateName = n[0];
+        var refTemplateName= n[1] || n[2];
 
-        const alias: string = getMatchingVariable(n[0], content);
-        if (alias) {
-            insertRefs(n[1] || n[2], file, lineNr, allVariablePathMaps);
+        // Why not look for lineNr using n[1] instead?, n[0] seems to be matching too many stuff
+        try {
+            if(alreadyProcessedTemplates[templateName]) continue;
+        
+            if(n[0] != "..") { // Searching for .. Brings back more than 200k results on some files
+                const lineNr = linenumber(content, templateName);
+                if(shouldLog) console.log("Before: ", lineNr);
+
+                const alias: string = getMatchingVariable(templateName, content);
+                if (alias) {
+                    insertRefs(refTemplateName, file, lineNr, allVariablePathMaps);
+                    if(shouldLog) console.log("Alias: ", alias);
+                }
+
+                insertRefs(refTemplateName, file, lineNr, allVariablePathMaps);
+                if(shouldLog) console.log("After: ", alias, n, allVariablePathMaps);
+            }
+            alreadyProcessedTemplates[templateName] = true; // linenumber returns all possible paths where n[0] is being used so just don't process it again
+        } catch(e){
+            console.error(e);
         }
-
-        insertRefs(n[1] || n[2], file, lineNr, allVariablePathMaps);
     }
 }
 // export function parseFile (file: string, allCallMaps: VariablePathMap) {

--- a/client/src/reference-provider/parse.ts
+++ b/client/src/reference-provider/parse.ts
@@ -60,8 +60,6 @@ export function parseFile (file: string, allVariablePathMaps: VariablePathMap) {
     let n: RegExpExecArray;
     console.log("Parsing File...", file);
 
-    var tt = "c:/Users/rober/Documents/Dev/Github/BeyondMeleeDev/System/asm/m-ex/Main.s"
-    var shouldLog = false ;//file == tt;
     var alreadyProcessedTemplates = {};
     while (n = variablePattern.exec(content)) {
         var templateName = n[0];
@@ -73,16 +71,14 @@ export function parseFile (file: string, allVariablePathMaps: VariablePathMap) {
         
             if(n[0] != "..") { // Searching for .. Brings back more than 200k results on some files
                 const lineNr = linenumber(content, templateName);
-                if(shouldLog) console.log("Before: ", lineNr);
 
                 const alias: string = getMatchingVariable(templateName, content);
                 if (alias) {
                     insertRefs(refTemplateName, file, lineNr, allVariablePathMaps);
-                    if(shouldLog) console.log("Alias: ", alias);
                 }
 
                 insertRefs(refTemplateName, file, lineNr, allVariablePathMaps);
-                if(shouldLog) console.log("After: ", alias, n, allVariablePathMaps);
+        
             }
             alreadyProcessedTemplates[templateName] = true; // linenumber returns all possible paths where n[0] is being used so just don't process it again
         } catch(e){

--- a/client/src/reference-provider/parse.ts
+++ b/client/src/reference-provider/parse.ts
@@ -2,7 +2,6 @@ import linenumber = require('linenumber');
 import fs = require('fs');
 import { getIncludes, getMatchingVariable, normalizeAliasTemplate } from '../template-utils';
 import { VariablePathDescription, VariablePathMap } from '../interfaces';
-import { nextTick } from 'node:process';
 
 function escapeRegExp (unescapedString: string) {
     return unescapedString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "powerpc-syntax",
-    "version": "1.1.4",
+    "version": "1.1.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This adds some light fixes that would prevent relatively long files and codeset from being parsed.
I found some more stuff that could be improved and I note them as comments on the files I changed.

I also recommend testing this with Akaneia's mEX codebase as a Source Root: https://github.com/akaneia/m-ex/tree/master/asm